### PR TITLE
Make tests run in recent appengine.

### DIFF
--- a/datastore/compare_test.go
+++ b/datastore/compare_test.go
@@ -3,7 +3,7 @@ package datastore
 import (
 	"appengine/datastore"
 	pb "appengine_internal/datastore"
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"testing"
 )
 

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,10 @@ Package for testing App Engine in golang without using the dev server. A faster 
 
 An in memory datastore
 
+## run tests
+
+    goapp test -v ./...
+
 ### Not supported / TODOS
 
 * slice values (order ++)


### PR DESCRIPTION
I wasn't able to run the tests using a recent App Engine SDK because the protobuf package wasn't found. By just changing the import paths the tests can run. Also added instructions on how to run the tests.
